### PR TITLE
feat: Support subPackages config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ export interface Options {
   dir: string
 
   /**
+   * subPackages 扫描的目录，例如：src/pages-sub
+   */
+  subPackages: string[]
+
+  /**
    * 输出 pages.json 目录
    * @default "src"
    */

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -7,7 +7,7 @@ import { slash } from '@antfu/utils'
 import { isH5 } from '@uni-helper/uni-env'
 import dbg from 'debug'
 import type { PagesConfig } from './config/types'
-import type { PageMetaDatum, PagePath, ResolvedOptions, UserOptions } from './types'
+import type { PageMetaDatum, PagePath, ResolvedOptions, SubPageMetaDatum, UserOptions } from './types'
 import { debug, getPagesConfigSourcePaths, invalidatePagesModule, isConfigFile, isTargetFile, mergePageMetaDataArray } from './utils'
 import { resolveOptions } from './options'
 import { checkPagesJsonFile, getPageFiles, writeFileSync } from './files'
@@ -18,8 +18,12 @@ export class PageContext {
   private _server: ViteDevServer | undefined
 
   pagesGlobConfig: PagesConfig | undefined
+
   pagesPath: PagePath[] = []
+  subPagesPath: Record<string, PagePath[]> = {}
   pageMetaData: PageMetaDatum[] = []
+  subPageMetaData: SubPageMetaDatum[] = []
+
   resolvedPagesJSONPath = ''
 
   rawOptions: UserOptions
@@ -57,21 +61,21 @@ export class PageContext {
 
   async scanPages() {
     const pageDirFiles = this.options.dirs.map((dir) => {
-      const pagesDirPath = slash(path.resolve(this.options.root, dir))
-      const basePath = slash(path.join(this.options.root, this.options.outDir))
-      const files = getPageFiles(pagesDirPath, this.options)
-      debug.pages(dir, files)
-      const pagePaths = files.map(file => slash(file))
-        .map(file => ({
-          relativePath: path.relative(basePath, slash(path.resolve(pagesDirPath, file))),
-          absolutePath: slash(path.resolve(pagesDirPath, file)),
-        }))
-
-      return { dir, files: pagePaths }
+      return { dir, files: getPagePaths(dir, this.options) }
     })
 
     this.pagesPath = pageDirFiles.map(page => page.files).flat()
     debug.pages(this.pagesPath)
+  }
+
+  async scanSubPages() {
+    const subPagesPath: Record<string, PagePath[]> = {}
+    for (const dir of this.options.subPackages) {
+      const pagePaths = getPagePaths(dir, this.options)
+      subPagesPath[dir] = pagePaths
+    }
+    this.subPagesPath = subPagesPath
+    debug.subPages(this.subPagesPath)
   }
 
   setupViteServer(server: ViteDevServer) {
@@ -141,26 +145,45 @@ export class PageContext {
     return pageMetaDatum
   }
 
-  async mergePageMetaData() {
+  async parsePages(pages: PagePath[], overrides?: PageMetaDatum[]) {
     const generatedPageMetaData = await Promise.all(
-      this.pagesPath.map(async page => await this.parsePage(page)),
+      pages.map(async page => await this.parsePage(page)),
     )
-    const customPageMetaData = this.pagesGlobConfig?.pages || []
+    const customPageMetaData = overrides || []
 
-    if (!this.options.mergePages) {
-      this.pageMetaData = customPageMetaData
+    const result = customPageMetaData.length
+      ? mergePageMetaDataArray(generatedPageMetaData.concat(customPageMetaData))
+      : generatedPageMetaData
+
+    result.sort(page => (page.type === 'home' ? -1 : 0))
+
+    return result
+  }
+
+  async mergePageMetaData() {
+    const pageMetaData = await this.parsePages(this.pagesPath, this.pagesGlobConfig?.pages)
+    this.pageMetaData = pageMetaData
+    debug.pages(this.pageMetaData)
+  }
+
+  async mergeSubPageMetaData() {
+    const subPageMaps: Record<string, PageMetaDatum[]> = {}
+    const subPackages = this.pagesGlobConfig?.subPackages
+
+    for (const [dir, pages] of Object.entries(this.subPagesPath)) {
+      const root = path.basename(dir)
+
+      const globPackage = subPackages?.find(v => v.root === root)
+      subPageMaps[root] = await this.parsePages(pages, globPackage?.pages)
+      subPageMaps[root] = subPageMaps[root].map(page => ({ ...page, path: slash(path.relative(root, page.path)) }))
     }
-    else {
-      if (this.pagesGlobConfig?.pages)
-        this.pageMetaData = mergePageMetaDataArray(generatedPageMetaData.concat(customPageMetaData))
 
-      else
-        this.pageMetaData = generatedPageMetaData
-    }
+    const subPageMetaData = Object
+      .keys(subPageMaps)
+      .map(root => ({ root, pages: subPageMaps[root] }))
 
-    this.pageMetaData.sort(page => (page.type === 'home' ? -1 : 0))
-
-    debug.pages(generatedPageMetaData)
+    this.subPageMetaData = subPageMetaData
+    debug.subPages(this.subPageMetaData)
   }
 
   async updatePagesJSON() {
@@ -172,16 +195,26 @@ export class PageContext {
     if (this.options.mergePages) {
       this.options.onBeforeScanPages(this)
       await this.scanPages()
+      await this.scanSubPages()
       this.options.onAfterScanPages(this)
     }
 
     this.options.onBeforeMergePageMetaData(this)
     await this.mergePageMetaData()
+    await this.mergeSubPageMetaData()
     this.options.onAfterMergePageMetaData(this)
 
     this.options.onBeforeWriteFile(this)
-    const pagesJson = JSON.stringify({ ...this.pagesGlobConfig, pages: this.pageMetaData }, null, this.options.minify ? undefined : 2)
+
+    const data = {
+      ...this.pagesGlobConfig,
+      pages: this.pageMetaData,
+      subPackages: this.subPageMetaData,
+    }
+
+    const pagesJson = JSON.stringify(data, null, this.options.minify ? undefined : 2)
     writeFileSync(this.resolvedPagesJSONPath, pagesJson)
+
     this.options.onAfterWriteFile(this)
   }
 
@@ -192,4 +225,18 @@ export class PageContext {
   resolveRoutes() {
     return JSON.stringify(this.pageMetaData, null, 2)
   }
+}
+
+function getPagePaths(dir: string, options: ResolvedOptions) {
+  const pagesDirPath = slash(path.resolve(options.root, dir))
+  const basePath = slash(path.join(options.root, options.outDir))
+  const files = getPageFiles(pagesDirPath, options)
+  debug.pages(dir, files)
+  const pagePaths = files.map(file => slash(file))
+    .map(file => ({
+      relativePath: path.relative(basePath, slash(path.resolve(pagesDirPath, file))),
+      absolutePath: slash(path.resolve(pagesDirPath, file)),
+    }))
+
+  return pagePaths
 }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -168,7 +168,7 @@ export class PageContext {
 
   async mergeSubPageMetaData() {
     const subPageMaps: Record<string, PageMetaDatum[]> = {}
-    const subPackages = this.pagesGlobConfig?.subPackages
+    const subPackages = this.pagesGlobConfig?.subPackages || []
 
     for (const [dir, pages] of Object.entries(this.subPagesPath)) {
       const root = path.basename(dir)
@@ -176,6 +176,12 @@ export class PageContext {
       const globPackage = subPackages?.find(v => v.root === root)
       subPageMaps[root] = await this.parsePages(pages, globPackage?.pages)
       subPageMaps[root] = subPageMaps[root].map(page => ({ ...page, path: slash(path.relative(root, page.path)) }))
+    }
+
+    // Inherit subPackages that do not exist in the config
+    for (const { root, pages } of subPackages) {
+      if (root && !subPageMaps[root])
+        subPageMaps[root] = pages || []
     }
 
     const subPageMetaData = Object

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -6,6 +6,8 @@ export function resolveOptions(userOptions: UserOptions, viteRoot?: string): Res
   const {
     mergePages = true,
     dir = 'src/pages',
+    subPackages = [],
+
     outDir = 'src',
     exclude = ['node_modules', '.git', '**/__*__/**'],
     routeBlockLang = 'json5',
@@ -24,10 +26,12 @@ export function resolveOptions(userOptions: UserOptions, viteRoot?: string): Res
 
   const root = viteRoot || slash(process.cwd())
   const resolvedDirs = resolvePageDirs(dir, root, exclude)
+  const resolvedSubDirs = subPackages.map(dir => slash(dir))
 
   const resolvedOptions: ResolvedOptions = {
     mergePages,
     dirs: resolvedDirs,
+    subPackages: resolvedSubDirs,
     outDir,
     exclude,
     routeBlockLang,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -23,6 +23,12 @@ export interface Options {
   dir: string
 
   /**
+   * all root directories loaded by subPackages
+   * @default []
+   */
+  subPackages: string[]
+
+  /**
    * pages.json dir
    * @default "src"
    */
@@ -74,6 +80,7 @@ export interface ResolvedOptions extends Omit<Options, 'dir'> {
    * Resolved page dirs
    */
   dirs: string[]
+
 }
 
 export interface PagePath {
@@ -96,4 +103,9 @@ export interface PageMetaDatum {
    */
   needLogin?: boolean
   [x: string]: any
+}
+
+export interface SubPageMetaDatum {
+  root: string
+  pages: PageMetaDatum[]
 }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -21,6 +21,7 @@ export const debug = {
   routeBlock: Debug('vite-plugin-uni-pages:routeBlock'),
   options: Debug('vite-plugin-uni-pages:options'),
   pages: Debug('vite-plugin-uni-pages:pages'),
+  subPages: Debug('vite-plugin-uni-pages:subPages'),
   error: Debug('vite-plugin-uni-pages:error'),
 }
 

--- a/packages/playground/src/pages-sub/about/index.vue
+++ b/packages/playground/src/pages-sub/about/index.vue
@@ -1,0 +1,7 @@
+<script></script>
+
+<template>
+  <div>
+    my
+  </div>
+</template>

--- a/packages/playground/src/pages-sub/about/your.vue
+++ b/packages/playground/src/pages-sub/about/your.vue
@@ -1,0 +1,7 @@
+<script></script>
+
+<template>
+  <div>
+    your
+  </div>
+</template>

--- a/packages/playground/src/pages-sub/index.vue
+++ b/packages/playground/src/pages-sub/index.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const title = ref('Hello')
+function nav() {
+  uni.navigateTo({
+    url: '/pages/about/index',
+  })
+}
+</script>
+
+<template>
+  <view class="content">
+    <image class="logo" src="/static/logo.png" />
+    <view class="text-area">
+      <text class="title">
+        {{ title }}
+      </text>
+    </view>
+    <button @click="nav">
+      nav
+    </button>
+  </view>
+</template>
+
+<style>
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.logo {
+  height: 200rpx;
+  width: 200rpx;
+  margin-top: 200rpx;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 50rpx;
+}
+
+.text-area {
+  display: flex;
+  justify-content: center;
+}
+
+.title {
+  font-size: 36rpx;
+  color: #8f8f94;
+}
+</style>
+
+<route lang="jsonc">
+{
+  "style": {
+    "navigationBarTitleText": "test json sub page"
+  }
+}
+</route>

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -6,5 +6,6 @@ import UniPages from '@uni-helper/vite-plugin-uni-pages'
 export default defineConfig({
   plugins: [UniPages({
     debug: true,
+    subPackages: ['src/pages-sub'],
   }), uni()],
 })


### PR DESCRIPTION
### Description 描述

关闭 #73，支持 subPackages 分包目录

```ts
Pages({
  subPackages: [/* ...dirs */]
})
```

部分更改：

- 将部分 mergePageMetaData 逻辑抽离为 parsePages 供 pages 与 subPages 使用
- 将部分 scanPages 逻辑抽离为 getPagePaths 供 pages 与 subPages 使用


### Additional context 额外上下文

察觉到已配置 eslintrc，却存在部分规则没能通过检查，例如：`core/index.ts`

![image](https://user-images.githubusercontent.com/49724027/232200560-f22ec9c3-fa59-4b4a-9b3d-456600be0c5d.png)

建议 commit 时进行自动修复（使用 lint-staged），可以避免不必要的麻烦
