### PR TITLE
fix: jsonc parse is empty

### DIFF
--- a/packages/core/src/customBlock.ts
+++ b/packages/core/src/customBlock.ts
@@ -1,4 +1,4 @@
-import fs from 'fs'
+import fs from 'node:fs'
 import JSON5 from 'json5'
 import { parse as YAMLParser } from 'yaml'
 import { parse as VueParser } from '@vue/compiler-sfc'
@@ -38,7 +38,7 @@ export function parseCustomBlock(
   let content: Record<string, any> | undefined
   debug.routeBlock(`use ${lang} parser`)
 
-  if (lang === 'json5') {
+  if (lang === 'json5' || lang === 'jsonc') {
     try {
       content = JSON5.parse(block.content)
     }


### PR DESCRIPTION
### Description 描述

关闭 #75，修复 type 为 jsonc 时无法被解析（customBlock）
