### PR TITLE
fix: get pages.config in nodejs environment

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -63,7 +63,7 @@ export class PageContext {
   }
 
   async loadUserPagesConfig() {
-    const { config } = await loadConfig<PagesConfig>({ sources: [{ files: 'pages.config' }] })
+    const { config } = await loadConfig<PagesConfig>({ cwd: this.root, sources: [{ files: 'pages.config' }] })
     if (!config) {
       this.logger?.warn('Can\'t found pages.config, please create pages.config.(ts|mts|cts|js|cjs|mjs|json)')
       process.exit(-1)


### PR DESCRIPTION


### Description 描述
解决独立node环境下无法正确获取pages.config文件问题


### Linked Issues 关联的 Issues
[issue#98](https://github.com/uni-helper/vite-plugin-uni-pages/issues/98)
