### PR TITLE
perf: Set the EasyCom option type to optional

### DIFF
--- a/packages/core/src/config/types/easycom.ts
+++ b/packages/core/src/config/types/easycom.ts
@@ -1,4 +1,4 @@
 export interface EasyCom {
-  autoscan: boolean
-  custom: Record<string, string>
+  autoscan?: boolean
+  custom?: Record<string, string>
 }


### PR DESCRIPTION
perf #120 ，增加 easycom 内配置项 ts 类型可选

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the configuration options to allow more flexibility. Optional settings for automatic scanning and custom configurations are now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->