### PR TITLE
fix(core): fix subPackage cannot exceed the second-level dir

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -19,7 +19,7 @@ import {
   useCachedPages,
 } from './utils'
 import { resolveOptions } from './options'
-import { checkPagesJsonFile, getPageFiles, writeFileSync } from './files'
+import { checkPagesJsonFile, getPageFiles, getSubPageDirs, writeFileSync } from './files'
 import { getRouteBlock, getRouteSfcBlock } from './customBlock'
 import { OUTPUT_NAME } from './constant'
 
@@ -85,10 +85,14 @@ export class PageContext {
 
   async scanSubPages() {
     const subPagesPath: Record<string, PagePath[]> = {}
-    for (const dir of this.options.subPackages) {
-      const pagePaths = getPagePaths(dir, this.options)
-      subPagesPath[dir] = pagePaths
+    for (const dirs of this.options.subPackages) {
+      getSubPageDirs(dirs).forEach((dir) => {
+        const pagePaths = getPagePaths(dir, this.options)
+
+        subPagesPath[dir] = pagePaths
+      })
     }
+
     this.subPagesPath = subPagesPath
     debug.subPages(this.subPagesPath)
   }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -245,7 +245,8 @@ export class PageContext {
     const subPackages = this.pagesGlobConfig?.subPackages || []
 
     for (const [dir, pages] of Object.entries(this.subPagesPath)) {
-      const root = path.basename(dir)
+      const basePath = slash(path.join(this.options.root, this.options.outDir))
+      const root = slash(path.relative(basePath, dir))
 
       const globPackage = subPackages?.find(v => v.root === root)
       subPageMaps[root] = await this.parsePages(pages, 'sub', globPackage?.pages)

--- a/packages/core/src/files.ts
+++ b/packages/core/src/files.ts
@@ -22,6 +22,14 @@ export function getPageFiles(path: string, options: ResolvedOptions): string[] {
   return files
 }
 
+export function getSubPageDirs(path: string): string[] {
+  const dirs = fg.sync(path, {
+    onlyDirectories: true,
+  })
+
+  return dirs
+}
+
 export function checkPagesJsonFile(path: string) {
   if (!fs.existsSync(path)) {
     writeFileSync(path, JSON.stringify({ pages: [{ path: '' }] }, null, 2))

--- a/packages/playground/src/pages-sub-more/home/pages/about/index.vue
+++ b/packages/playground/src/pages-sub-more/home/pages/about/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello This is index page in 'about' dir
+  </div>
+</template>

--- a/packages/playground/src/pages-sub-more/home/pages/index.vue
+++ b/packages/playground/src/pages-sub-more/home/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello This is index page in 'home'
+  </div>
+</template>

--- a/packages/playground/src/pages-sub-more/user/pages/index.vue
+++ b/packages/playground/src/pages-sub-more/user/pages/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    Hello This is index page in 'user'
+  </div>
+</template>

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import type { UserPagesConfig } from '../packages/core/src'
 import { PageContext } from '../packages/core/src'
 
@@ -92,7 +92,7 @@ describe('generate routes', () => {
   })
 
   it('vue - not merge pages snapshot', async () => {
-    const ctx = new PageContext({ dir: 'packages/playground/src/pages', mergePages: false })
+    const ctx = new PageContext({ dir: 'packages/playground/src/pages' })
     await ctx.scanPages()
     ctx.pagesGlobConfig = pagesGlobConfig
     await ctx.mergePageMetaData()
@@ -170,6 +170,42 @@ describe('generate routes', () => {
           "style": {}
         }
       ]"
+    `)
+  })
+
+  it('support glob patterns in subPackage', async () => {
+    const ctx = new PageContext({
+      subPackages: ['packages/playground/src/pages-sub-more/*'],
+    })
+    await ctx.scanSubPages()
+    await ctx.mergeSubPageMetaData()
+    const routes = ctx.resolveSubRoutes()
+
+    expect(routes).toMatchInlineSnapshot(`
+    "[
+      {
+        "root": "home",
+        "pages": [
+          {
+            "path": "../../packages/playground/src/pages-sub-more/home/pages/index",
+            "type": "page"
+          },
+          {
+            "path": "../../packages/playground/src/pages-sub-more/home/pages/about/index",
+            "type": "page"
+          }
+        ]
+      },
+      {
+        "root": "user",
+        "pages": [
+          {
+            "path": "../../packages/playground/src/pages-sub-more/user/pages/index",
+            "type": "page"
+          }
+        ]
+      }
+    ]"
     `)
   })
 })

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -184,23 +184,23 @@ describe('generate routes', () => {
     expect(routes).toMatchInlineSnapshot(`
     "[
       {
-        "root": "home",
+        "root": "../packages/playground/src/pages-sub-more/home",
         "pages": [
           {
-            "path": "../../packages/playground/src/pages-sub-more/home/pages/index",
+            "path": "pages/index",
             "type": "page"
           },
           {
-            "path": "../../packages/playground/src/pages-sub-more/home/pages/about/index",
+            "path": "pages/about/index",
             "type": "page"
           }
         ]
       },
       {
-        "root": "user",
+        "root": "../packages/playground/src/pages-sub-more/user",
         "pages": [
           {
-            "path": "../../packages/playground/src/pages-sub-more/user/pages/index",
+            "path": "pages/index",
             "type": "page"
           }
         ]


### PR DESCRIPTION
修复当分包拥有二级目录以上时，root和path路径无法正确生成问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new way to handle subdirectories in the app, enhancing navigation and organization of pages.
	- Added new index pages for the 'home', 'about', and 'user' sections with greeting messages.

- **Bug Fixes**
	- Fixed the calculation of base paths in page parsing to ensure correct directory handling.

- **Tests**
	- Updated and added tests to support new directory handling features and ensure robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->