### PR TITLE
fix(core): fix subPackage cannot match the second-level dir

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -241,7 +241,8 @@ export class PageContext {
     const subPackages = this.pagesGlobConfig?.subPackages || []
 
     for (const [dir, pages] of Object.entries(this.subPagesPath)) {
-      const root = path.basename(dir)
+      const basePath = slash(path.join(this.options.root, this.options.outDir))
+      const root = slash(path.relative(basePath, dir))
 
       const globPackage = subPackages?.find(v => v.root === root)
       subPageMaps[root] = await this.parsePages(pages, 'sub', globPackage?.pages)

--- a/packages/playground/src/pages-sub-pages/sub-activity/pages/about/index.vue
+++ b/packages/playground/src/pages-sub-pages/sub-activity/pages/about/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    this is subPackage second-level dir about
+  </div>
+</template>

--- a/packages/playground/src/pages-sub-pages/sub-activity/pages/home/index.vue
+++ b/packages/playground/src/pages-sub-pages/sub-activity/pages/home/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    this is subPackage second-level dir home
+  </div>
+</template>

--- a/packages/playground/src/pages-sub-pages/sub-main/pages/about/index.vue
+++ b/packages/playground/src/pages-sub-pages/sub-main/pages/about/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    this is subPackage second-level dir about
+  </div>
+</template>

--- a/packages/playground/src/pages-sub-pages/sub-main/pages/home/index.vue
+++ b/packages/playground/src/pages-sub-pages/sub-main/pages/home/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    this is subPackage second-level dir home
+  </div>
+</template>

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import type { UserPagesConfig } from '../packages/core/src'
 import { PageContext } from '../packages/core/src'
 
@@ -170,6 +170,48 @@ describe('generate routes', () => {
           "style": {}
         }
       ]"
+    `)
+  })
+
+  it('fix subPackage cannot match the second-level dir', async () => {
+    const ctx = new PageContext({
+      subPackages: [
+        'packages/playground/src/pages-sub-pages/sub-activity',
+        'packages/playground/src/pages-sub-pages/sub-main',
+      ],
+    })
+    await ctx.scanSubPages()
+    await ctx.mergeSubPageMetaData()
+    const routes = ctx.resolveSubRoutes()
+    expect(routes).toMatchInlineSnapshot(`
+    "[
+      {
+        "root": "../packages/playground/src/pages-sub-pages/sub-activity",
+        "pages": [
+          {
+            "path": "pages/about/index",
+            "type": "page"
+          },
+          {
+            "path": "pages/home/index",
+            "type": "page"
+          }
+        ]
+      },
+      {
+        "root": "../packages/playground/src/pages-sub-pages/sub-main",
+        "pages": [
+          {
+            "path": "pages/about/index",
+            "type": "page"
+          },
+          {
+            "path": "pages/home/index",
+            "type": "page"
+          }
+        ]
+      }
+    ]"
     `)
   })
 })


### PR DESCRIPTION
fixes: #152 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new About and Home pages for both 'sub-activity' and 'sub-main' sections in the playground package, enhancing navigation and user interaction.

- **Bug Fixes**
	- Improved the routing calculation in PageContext to ensure accurate path generation based on the project structure, enhancing reliability.

- **Tests**
	- Added new test case to address and fix the sub-package matching issue for second-level directories, ensuring robust functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->