### PR TITLE
fix: resolve path in HBuilderX

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -242,7 +242,7 @@ export class PageContext {
 
     for (const [dir, pages] of Object.entries(this.subPagesPath)) {
       const basePath = slash(path.join(this.options.root, this.options.outDir))
-      const root = slash(path.relative(basePath, dir))
+      const root = slash(path.relative(basePath, path.join(this.options.root, dir)))
 
       const globPackage = subPackages?.find(v => v.root === root)
       subPageMaps[root] = await this.parsePages(pages, 'sub', globPackage?.pages)


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing! We highly recommend reading [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer) first to get an idea of our current state, and we appreciate your understanding!
感谢你的贡献！我们非常推荐先阅读 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer) 以了解我们目前的状态，感谢你的理解！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述
#### 子包目录解析会报错：
<img width="770" alt="image" src="https://github.com/uni-helper/vite-plugin-uni-pages/assets/3348428/654c85c1-b9c7-421c-8a10-577ff29930bc">

#### 解决办法：
https://github.com/uni-helper/vite-plugin-uni-pages/blob/4459a1bfaa6d14becd56f0272ee62f5705daea9e/packages/core/src/context.ts#L245
改成：
```typescript
      const root = slash(path.relative(basePath, path.join(this.options.root, dir)))
```
<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

### Linked Issues 关联的 Issues
无
### Additional context 额外上下文
在 HBuilderX 下运行
<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the calculation of the base path in the application to include additional path components, improving navigation and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->