### PR TITLE
fix: fix HBuilderX compatibility

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,7 +26,7 @@ export * from './customBlock'
 async function restart() {
   return new Promise((resolve) => {
     const build = spawn(process.argv.shift()!, process.argv, {
-      cwd: process.cwd(),
+      cwd: process.env.VITE_ROOT_DIR!,
       detached: true,
       env: process.env,
     })
@@ -43,7 +43,7 @@ export function VitePluginUniPages(userOptions: UserOptions = {}): Plugin {
 
   // TODO: check if the pages.json file is valid
   const resolvedPagesJSONPath = path.join(
-    process.cwd(),
+    process.env.VITE_ROOT_DIR!,
     userOptions.outDir ?? 'src',
     OUTPUT_NAME,
   )

--- a/packages/core/src/options.ts
+++ b/packages/core/src/options.ts
@@ -31,7 +31,7 @@ export function resolveOptions(userOptions: UserOptions, viteRoot: string = proc
     onAfterWriteFile = () => {},
   } = userOptions
 
-  const root = viteRoot || slash(process.cwd())
+  const root = viteRoot || slash(process.env.VITE_ROOT_DIR!) || slash(process.cwd())
   const resolvedDirs = resolvePageDirs(dir, root, exclude)
   const resolvedSubDirs = subPackages.map(dir => slash(dir))
   const resolvedHomePage = typeof homePage === 'string' ? [homePage] : homePage


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Thank you for contributing! We highly recommend reading [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer) first to get an idea of our current state, and we appreciate your understanding!
感谢你的贡献！我们非常推荐先阅读 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer) 以了解我们目前的状态，感谢你的理解！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述
兼容 HBuiderX 运行模式
<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。

-->

### Linked Issues 关联的 Issues
在 HBuiderX 使用，会在 /Applications/HBuilderX.app/Contents/HBuilderX/plugins/uniapp-cli-vite/ 下生成一个 pages.json 文件
### Additional context 额外上下文
在 HBuilderX 下运行
<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced path resolution by using the `VITE_ROOT_DIR` environment variable for better flexibility and configuration.
  
- **Improvements**
  - Updated internal path calculations to ensure consistency with the new environment variable setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->