### PR TITLE
fix(core): fix the module exports

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -78,9 +78,9 @@ export class PageContext {
   async loadUserPagesConfig() {
     const configSource = this.options.configSource
     const { config, sources } = await loadConfig<PagesConfig>({ cwd: this.root, sources: configSource, defaults: {} })
-    this.pagesGlobConfig = config
+    this.pagesGlobConfig = config?.default || config
     this.pagesConfigSourcePaths = sources
-    debug.options(config)
+    debug.options(this.pagesGlobConfig)
   }
 
   async scanPages() {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -78,7 +78,7 @@ export class PageContext {
   async loadUserPagesConfig() {
     const configSource = this.options.configSource
     const { config, sources } = await loadConfig<PagesConfig>({ cwd: this.root, sources: configSource, defaults: {} })
-    this.pagesGlobConfig = config?.default || config
+    this.pagesGlobConfig = config.default || config
     this.pagesConfigSourcePaths = sources
     debug.options(this.pagesGlobConfig)
   }


### PR DESCRIPTION
fixed: #178

主因是 `unconfig` 依赖升级导致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of user pages configuration to avoid potential issues with undefined or missing default values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->