### PR TITLE
feat: suport definePage

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,22 @@ export default defineUniPages({
 
 现在所有的 page 都会被自动发现！
 
-### SFC 自定义块用于路由数据
+### 自定义路由数据
 
+#### 1、definePage 定义路由数据
+可以在setup中使用 definePage 来定义路由数据。 注意解析definePage是在编译期 不能使用运行期的变量
+
+```ts
+import { definePage } from '@uni-helper/vite-plugin-uni-pages'
+
+definePage({
+  style:{
+    navigationBarTitleText: 'test'
+  }
+})
+```
+
+#### 2、SFC 自定义块用于路由数据
 通过添加一个 `<route>` 块到 SFC 中来添加路由元数据。这将会在路由生成后直接添加到路由中，并且会覆盖。
 
 你可以使用 `<route lang="yaml">` 来指定一个解析器，或者使用 `routeBlockLang` 选项来设置一个默认的解析器。

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,10 @@
     "vite": "^5.0.0"
   },
   "dependencies": {
+    "@babel/generator": "^7.25.5",
+    "@babel/types": "^7.25.4",
     "@uni-helper/uni-env": "^0.1.4",
+    "@vue-macros/common": "^1.12.2",
     "@vue/compiler-sfc": "^3.4.38",
     "chokidar": "^3.6.0",
     "debug": "^4.3.6",
@@ -70,6 +73,7 @@
   },
   "devDependencies": {
     "@antfu/utils": "^0.7.10",
+    "@types/babel__generator": "^7.6.8",
     "@types/debug": "^4.1.12",
     "@types/lodash.groupby": "^4.6.9",
     "@types/node": "^20.15.0",

--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -4,3 +4,5 @@ export const RESOLVED_MODULE_ID_VIRTUAL = `\0${MODULE_ID_VIRTUAL}`
 export const OUTPUT_NAME = 'pages.json'
 
 export const FILE_EXTENSIONS = ['vue', 'nvue', 'uvue']
+
+export const MACRO_DEFINE_PAGE = 'definePage'

--- a/packages/core/src/customBlock.ts
+++ b/packages/core/src/customBlock.ts
@@ -1,8 +1,7 @@
-import fs from 'node:fs'
 import JSON5 from 'json5'
 import { parse as YAMLParser } from 'yaml'
-import { parse as VueParser } from '@vue/compiler-sfc'
 import type { SFCBlock, SFCDescriptor } from '@vue/compiler-sfc'
+import { parse as VueParser } from '@vue/compiler-sfc'
 import { debug } from './utils'
 import type { CustomBlock, ResolvedOptions } from './types'
 
@@ -72,13 +71,8 @@ export function parseCustomBlock(
   }
 }
 
-export async function getRouteSfcBlock(path: string): Promise<SFCBlock | undefined> {
-  const content = fs.readFileSync(path, 'utf8')
-
-  const parsedSFC = await parseSFC(content)
-  const blockStr = parsedSFC?.customBlocks.find(b => b.type === 'route')
-
-  return blockStr
+export async function getRouteSfcBlock(parsedSFC: SFCDescriptor): Promise<SFCBlock | undefined> {
+  return parsedSFC?.customBlocks.find(b => b.type === 'route')
 }
 
 export async function getRouteBlock(path: string, blockStr: SFCBlock | undefined, options: ResolvedOptions): Promise<CustomBlock | undefined> {

--- a/packages/core/src/definePage.ts
+++ b/packages/core/src/definePage.ts
@@ -1,0 +1,87 @@
+import type { SFCDescriptor, SFCScriptBlock } from '@vue/compiler-sfc'
+import { babelParse, isCallOf } from '@vue-macros/common'
+import * as t from '@babel/types'
+import generate from '@babel/generator'
+import { MACRO_DEFINE_PAGE } from './constant'
+import type { PageMetaDatum } from './types'
+
+function findMacroWithImports(scriptSetup: SFCScriptBlock | null) {
+  const empty = { imports: [], macro: undefined }
+
+  if (!scriptSetup)
+    return empty
+
+  const parsed = babelParse(scriptSetup.content, scriptSetup.lang || 'js', {
+    plugins: [['importAttributes', { deprecatedAssertSyntax: true }]],
+  })
+
+  const stmts = parsed.body
+
+  const nodes = stmts
+    .map((raw: t.Node) => {
+      let node = raw
+      if (raw.type === 'ExpressionStatement')
+        node = raw.expression
+      return isCallOf(node, MACRO_DEFINE_PAGE) ? node : undefined
+    })
+    .filter((node): node is t.CallExpression => !!node)
+
+  if (!nodes.length)
+    return empty
+
+  if (nodes.length > 1)
+    throw new Error(`duplicate ${MACRO_DEFINE_PAGE}() call`)
+
+  const macro = nodes[0]
+
+  const [arg] = macro.arguments
+
+  if (arg && !t.isFunctionExpression(arg) && !t.isArrowFunctionExpression(arg) && !t.isObjectExpression(arg))
+    throw new Error(`${MACRO_DEFINE_PAGE}() only accept argument in function or object`)
+
+  const imports = stmts
+    .map((node: t.Node) => (node.type === 'ImportDeclaration') ? node : undefined)
+    .filter((node): node is t.ImportDeclaration => !!node)
+
+  return {
+    imports,
+    macro,
+  }
+}
+
+export async function readPageOptionsFromMacro(sfc: SFCDescriptor) {
+  const { macro } = findMacroWithImports(sfc.scriptSetup)
+
+  if (!macro)
+    return {}
+
+  if (sfc?.customBlocks.find(b => b.type === 'route'))
+    throw new Error(`mixed ${MACRO_DEFINE_PAGE}() and <route/> is not allowed`)
+
+  const [arg] = macro.arguments
+
+  if (!arg)
+    return {}
+
+  let code
+  if (typeof generate === 'function') {
+    code = generate(arg).code
+  }
+  else {
+    code = (generate as any).default(arg).code
+  }
+
+  const script = t.isFunctionExpression(arg) || t.isArrowFunctionExpression(arg)
+    ? `return await Promise.resolve((${code})())`
+    : `return ${code}`
+
+  const AsyncFunction = Object.getPrototypeOf(async () => { }).constructor
+
+  const fn = new AsyncFunction(script)
+
+  return await fn() as Partial<PageMetaDatum>
+}
+
+export function findMacro(scriptSetup: SFCScriptBlock | null) {
+  return findMacroWithImports(scriptSetup).macro
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -140,3 +140,8 @@ export interface SubPageMetaDatum {
   root: string
   pages: PageMetaDatum[]
 }
+
+export function definePage(_options: Partial<
+  PageMetaDatum
+>) {
+}

--- a/packages/playground/src/pages/test-define-page.vue
+++ b/packages/playground/src/pages/test-define-page.vue
@@ -1,0 +1,17 @@
+<script lang="ts" setup>
+import {definePage} from "@uni-helper/vite-plugin-uni-pages/src";
+definePage(()=>{
+ return {
+    style:{
+      backgroundColor: '#ffffff'
+    },
+    cus:88811155
+  }
+})
+const xm = ref("123")
+</script>
+
+<template>
+  <div>definePage2222</div>{{xm}}
+</template>
+

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -1,6 +1,7 @@
 import { resolve } from 'node:path'
+import fs from 'node:fs'
 import { describe, expect, it } from 'vitest'
-import { getRouteBlock, getRouteSfcBlock, resolveOptions } from '../packages/core/src/index'
+import { getRouteBlock, getRouteSfcBlock, parseSFC, resolveOptions } from '../packages/core/src/index'
 
 const options = resolveOptions({})
 const pagesJson = 'packages/playground/src/pages/test-json.vue'
@@ -9,7 +10,9 @@ const pagesYaml = 'packages/playground/src/pages/test-yaml.vue'
 describe('parser', () => {
   it('custom block', async () => {
     const path = resolve(pagesJson)
-    const str = await getRouteSfcBlock(path)
+    const content = fs.readFileSync(path, 'utf8')
+    const sfcDescriptor = await parseSFC(content)
+    const str = await getRouteSfcBlock(sfcDescriptor)
     const routeBlock = await getRouteBlock(path, str, options)
     expect(routeBlock).toMatchInlineSnapshot(`
       {
@@ -31,7 +34,9 @@ describe('parser', () => {
 
   it('yaml comment', async () => {
     const path = resolve(pagesYaml)
-    const str = await getRouteSfcBlock(path)
+    const content = fs.readFileSync(path, 'utf8')
+    const sfcDescriptor = await parseSFC(content)
+    const str = await getRouteSfcBlock(sfcDescriptor)
     const routeBlock = await getRouteBlock(path, str, options)
     expect(routeBlock).toMatchInlineSnapshot(`
       {


### PR DESCRIPTION
### Description 描述
feat: suport definePage
支持definePage定义路由信息




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced documentation for routing data management, including a new section on defining routing data.
	- Introduced `definePage` function for flexible page metadata handling.
	- Added a new Vue component example utilizing the `definePage` function.

- **Bug Fixes**
	- Improved logic for parsing and handling Single File Components (SFCs) to enhance reliability.

- **Documentation**
	- Updated README to clarify usage and structure of routing data and macros.

- **Chores**
	- Added new dependencies to improve tooling and TypeScript support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->