### PR TITLE
perf: break loop wihen found the first definePage

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -135,31 +135,28 @@ export async function tryPageMetaFromCustomBlock(sfc: SFCDescriptor, routeBlockL
 }
 
 export function findMacro(stmts: t.Statement[], filename: string): t.CallExpression | undefined {
-  const nodes = stmts
-    .map((raw: t.Node) => {
-      let node = raw
-      if (raw.type === 'ExpressionStatement')
-        node = raw.expression
-      return isCallOf(node, 'definePage') ? node : undefined
-    })
-    .filter((node): node is t.CallExpression => !!node)
+  let macro: t.CallExpression | undefined
 
-  if (!nodes.length)
-    return
+  for (const stmt of stmts) {
+    let node: t.Node = stmt
+    if (stmt.type === 'ExpressionStatement')
+      node = stmt.expression
 
-  if (nodes.length > 1) {
-    throw new Error(`每个文件只允许调用一次 definePage(): ${filename}`)
+    if (isCallOf(node, 'definePage')) {
+      macro = node
+      break
+    }
   }
 
-  // 仅第支持一个 definePage
-  const macro = nodes[0]
+  if (!macro)
+    return
 
   // 提取 macro function 内的第一个参数
   const [opt] = macro.arguments
 
   // 检查 macro 的参数是否正确
   if (opt && !t.isFunctionExpression(opt) && !t.isArrowFunctionExpression(opt) && !t.isObjectExpression(opt)) {
-    debug.definePage(`definePage() only accept argument in function or object: ${filename}`)
+    debug.definePage(`definePage() 参数仅支持函数或对象: ${filename}`)
     return
   }
 


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述


找到第一个 definePage 就跳出 loop，无须遍历整个 ast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Multiple page definitions no longer cause an error; the first definition is used automatically.
* **New Features**
  * Validation error message for an invalid page argument is now displayed in Chinese.
* **Refactor**
  * Internal logic streamlined for identifying the primary page definition without affecting public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->