### PR TITLE
fix #231 filter no named imports

### DIFF
--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -103,7 +103,7 @@ export async function tryPageMetaFromMacro(sfc: SFCDescriptor): Promise<UserPage
   })
   const macro = findMacro(ast.body, sfc.filename)
   if (macro) {
-    const imports = findImports(ast.body).map(imp => babelGenerate(imp).code)
+    const imports = findImports(ast.body).filter(imp => !!imp.specifiers.length).map(imp => babelGenerate(imp).code)
 
     const [macroOption] = macro.arguments
     const code = babelGenerate(macroOption).code

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -167,7 +167,12 @@ export function findMacro(stmts: t.Statement[], filename: string): t.CallExpress
 }
 
 export function findImports(stmts: t.Statement[]): t.ImportDeclaration[] {
-  return stmts
-    .map((node: t.Node) => (node.type === 'ImportDeclaration') ? node : undefined)
-    .filter((node): node is t.ImportDeclaration => !!node)
+  const imports: t.ImportDeclaration[] = []
+  for (const stmt of stmts) {
+    if (stmt.type !== 'ImportDeclaration') {
+      continue
+    }
+    imports.push(stmt)
+  }
+  return imports
 }

--- a/packages/core/src/page.ts
+++ b/packages/core/src/page.ts
@@ -169,10 +169,9 @@ export function findMacro(stmts: t.Statement[], filename: string): t.CallExpress
 export function findImports(stmts: t.Statement[]): t.ImportDeclaration[] {
   const imports: t.ImportDeclaration[] = []
   for (const stmt of stmts) {
-    if (stmt.type !== 'ImportDeclaration') {
-      continue
+    if (t.isImportDeclaration(stmt)) {
+      imports.push(stmt)
     }
-    imports.push(stmt)
   }
   return imports
 }


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

related #231 

解决当有非命名引用时，ts 转为 cjs 无法摇树，导致引入了 typescript 文件而出错的bug

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved page metadata processing by ignoring side-effect-only imports, preventing unintended side effects and producing more consistent results.

* **Refactor**
  * Streamlined import collection logic for better maintainability while preserving existing public behavior and interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->