### PR TITLE
fix: #242 解决无配置 tabbar 时，依然生成空数组的 tabbar 的bug

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -280,7 +280,19 @@ export class PageContext {
     debug.subPages(this.subPageMetaData)
   }
 
-  private async getTabBarMerged(): Promise<TabBar> {
+  private async getTabBarMerged(): Promise<TabBar | undefined> {
+    const tabBarItems: (TabBarItem & { index: number })[] = []
+    for (const [_, page] of this.pages) {
+      const tabbar = await page.getTabBar()
+      if (tabbar) {
+        tabBarItems.push(tabbar)
+      }
+    }
+
+    if (tabBarItems.length === 0) {
+      return this.pagesGlobConfig?.tabBar
+    }
+
     const tabBar = {
       ...this.pagesGlobConfig?.tabBar,
       list: this.pagesGlobConfig?.tabBar?.list || [],
@@ -289,14 +301,6 @@ export class PageContext {
     const pagePaths = new Map<string, boolean>()
     for (const item of tabBar.list) {
       pagePaths.set(item.pagePath, true)
-    }
-
-    const tabBarItems: (TabBarItem & { index: number })[] = []
-    for (const [_, page] of this.pages) {
-      const tabbar = await page.getTabBar()
-      if (tabbar) {
-        tabBarItems.push(tabbar)
-      }
     }
 
     tabBarItems.sort((a, b) => a.index - b.index)


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述


related #242 