### PR TITLE
feat: 为 H5 实现初始化 pages.json 的能力

### DIFF
--- a/packages/core/src/constant.ts
+++ b/packages/core/src/constant.ts
@@ -4,3 +4,4 @@ export const RESOLVED_MODULE_ID_VIRTUAL = `\0${MODULE_ID_VIRTUAL}`
 export const OUTPUT_NAME = 'pages.json'
 
 export const FILE_EXTENSIONS = ['vue', 'nvue', 'uvue']
+export const EMPTY_PAGES_JSON_CONTENTS = '{ "pages": [{ "path": "" }] }'

--- a/packages/core/src/files.ts
+++ b/packages/core/src/files.ts
@@ -72,9 +72,16 @@ export function setupPagesJsonFile(path: string) {
   fs.readFileSync = new Proxy(fs.readFileSync, {
     apply(target, thisArg, argArray) {
       if (typeof argArray[0] === 'string' && normalizePath(argArray[0]) === normalizePath(path)) {
-        checkPagesJsonFile(path).then(() => {
+        try {
+          const data = _readFileSync.apply(thisArg, argArray as any)
           fs.readFileSync = _readFileSync
-        })
+          return data
+        }
+        catch {
+          checkPagesJsonFile(path).then(() => {
+            fs.readFileSync = _readFileSync
+          })
+        }
         return EMPTY_PAGES_JSON_CONTENTS
       }
       return Reflect.apply(target, thisArg, argArray)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ import type { Plugin } from 'vite'
 import type { UserOptions } from './types'
 import path from 'node:path'
 import process from 'node:process'
+import { isH5 } from '@uni-helper/uni-env'
 import { babelParse } from 'ast-kit'
 import chokidar from 'chokidar'
 import { bold, dim, lightYellow, link } from 'kolorist'
@@ -15,7 +16,7 @@ import {
   RESOLVED_MODULE_ID_VIRTUAL,
 } from './constant'
 import { PageContext } from './context'
-import { checkPagesJsonFile } from './files'
+import { setupPagesJsonFile } from './files'
 import { findMacro, parseSFC } from './page'
 
 export * from './config'
@@ -37,7 +38,9 @@ export async function VitePluginUniPages(userOptions: UserOptions = {}): Promise
     userOptions.outDir ?? 'src',
     OUTPUT_NAME,
   )
-  await checkPagesJsonFile(resolvedPagesJSONPath)
+  if (isH5) {
+    setupPagesJsonFile(resolvedPagesJSONPath)
+  }
 
   return {
     name: 'vite-plugin-uni-pages',


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

此 PR 为 H5 实现了初始化 pages.json 的能力，启动时，即使目录下没有 pages.json 也不会崩溃。

当前 uni-app 在 h5 环境是直接用的 vite server，其 initEasycom 函数是后置的执行的，因此可以通过拦截 readFileSync 来生成并返回一个空的 pages.json 来骗过 uni cli 的初始化。

日后 uni 更新到 createBuilder 后，也可以用这种方式

https://github.com/dcloudio/uni-app/blob/c4d75050a2ab22c6ad2019df6bd1a6c8f15776d3/packages/vite-plugin-uni/src/cli/action.ts#L47-L50

### Linked Issues 关联的 Issues

### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatically initializes the pages configuration with sensible defaults when missing, enabling smoother first-time and recovery scenarios.
  * Ensures reads of the pages configuration are non-blocking, allowing the app to continue operating while the file is prepared.

* **Bug Fixes**
  * Prevents startup errors when the pages configuration file is absent or temporarily unreadable.
  * Limits setup to relevant environments, avoiding unnecessary initialization where not needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->