### PR TITLE
pages.json 内使用条件编译区分不同环境

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,7 +27,10 @@
       "runtimeExecutable": "pnpm",
       "runtimeArgs": ["run", "dev:mp-weixin"],
       "console": "integratedTerminal",
-      "internalConsoleOptions": "neverOpen"
+      "internalConsoleOptions": "neverOpen",
+      "env": {
+        "NODE_ENV": "development"
+      }
     }
   ]
 }

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -642,7 +642,10 @@ function mergePlatformItems<T = any>(source: CommentArray<CommentObject> | undef
       platformUsage[v.platformStr] = (platformUsage[v.platformStr] || 0) + 1
     })
   })
-  const defaultPlatformStr = Object.keys(platformUsage).reduce((a, b) => platformUsage[a] > platformUsage[b] ? a : b)
+  const usageKeys = Object.keys(platformUsage)
+  const defaultPlatformStr = usageKeys.length
+    ? usageKeys.reduce((a, b) => (platformUsage[a] > platformUsage[b] ? a : b))
+    : currentPlatform
 
   // 为 result 添加 Symbol.for(`before:0`) 添加生成标识注释
   result[Symbol.for('before:0') as CommentSymbol] = [{

--- a/packages/core/src/files.ts
+++ b/packages/core/src/files.ts
@@ -1,9 +1,9 @@
 import type { ResolvedOptions } from './types'
 import fs from 'node:fs'
 import fg from 'fast-glob'
-
+import lockfile from 'proper-lockfile'
 import { FILE_EXTENSIONS } from './constant'
-import { extsToGlob } from './utils'
+import { debug, extsToGlob, sleep } from './utils'
 
 /**
  * Resolves the files that are valid pages for the given context.
@@ -23,45 +23,110 @@ export function getPageFiles(path: string, options: ResolvedOptions): string[] {
 }
 
 /**
- * 检查指定路径的pages.json文件，如果文件不存在或不是有效文件则创建一个空的pages.json文件
+ * 检查指定路径的 pages.json 文件，如果文件不存在或不是有效文件则创建一个空的 pages.json 文件
  * @param path - 要检查的文件路径
- * @returns Promise<void> - 无返回值的异步函数
+ * @returns boolean - 返回操作是否成功
  */
-export async function checkPagesJsonFile(path: fs.PathLike): Promise<boolean> {
-  const createEmptyFile = (path: fs.PathLike) => {
-    return fs.promises.writeFile(path, JSON.stringify({ pages: [{ path: '' }] }, null, 2), { encoding: 'utf-8' }).then(() => true).catch(() => false)
+export function checkPagesJsonFileSync(path: fs.PathLike): boolean {
+  /**
+   * 创建空的 pages.json 文件
+   * @param path - 文件路径
+   * @returns boolean - 返回创建是否成功
+   */
+  const createEmptyFile = (path: fs.PathLike): boolean => {
+    try {
+      fs.writeFileSync(
+        path,
+        JSON.stringify({ pages: [{ path: '' }] }, null, 2),
+        { encoding: 'utf-8' },
+      )
+      return true
+    }
+    catch {
+      return false
+    }
   }
 
-  const unlink = (path: fs.PathLike) => {
-    return fs.promises.unlink(path).then(() => true).catch(() => false)
+  /**
+   * 删除指定路径的文件
+   * @param path - 文件路径
+   * @returns boolean - 返回删除是否成功
+   */
+  const unlinkFile = (path: fs.PathLike): boolean => {
+    try {
+      fs.unlinkSync(path)
+      return true
+    }
+    catch {
+      return false
+    }
   }
 
   try {
-    const stat = await fs.promises.stat(path)
+    // 检查文件是否存在
+    try {
+      fs.accessSync(path, fs.constants.F_OK)
+    }
+    catch {
+      // 文件不存在，创建新文件
+      return createEmptyFile(path)
+    }
 
+    // 检查是否为文件
+    const stat = fs.statSync(path)
     if (!stat.isFile()) {
-      // 不是文件，尝试删除
-      if (!await unlink(path)) {
+      // 不是文件，尝试删除并重新创建
+      if (!unlinkFile(path)) {
         return false
       }
-
-      return createEmptyFile(path) // 创建空文件
+      return createEmptyFile(path)
     }
-    // 是文件
 
-    const access = await fs.promises.access(path, fs.constants.W_OK | fs.constants.R_OK).then(() => true).catch(() => false)
-    if (!access) {
-      // 无权限，尝试删除
-      if (!await unlink(path)) {
+    // 检查读写权限
+    try {
+      fs.accessSync(path, fs.constants.R_OK | fs.constants.W_OK)
+
+      return true
+    }
+    catch {
+      // 权限不足，尝试删除并重新创建
+      if (!unlinkFile(path)) {
         return false
       }
-
-      return createEmptyFile(path) // 创建空文件
+      return createEmptyFile(path)
     }
-    return true
   }
   catch {
-    // stat 出错，证明没此文件
-    return createEmptyFile(path) // 创建空文件
+    // 发生其他错误，尝试创建文件
+    return createEmptyFile(path)
+  }
+}
+
+export async function writeFileWithLock(path: string, content: string, retry = 3) {
+  if (retry <= 0) {
+    debug.error(`${path} 获取文件锁失败，写入失败`)
+    return
+  }
+
+  let relase: () => Promise<void> | undefined
+
+  try {
+    try {
+      // 获取文件锁
+      relase = await lockfile.lock(path, { realpath: false })
+    }
+    catch {
+      // 获取文件锁失败
+      await sleep(500)
+      return writeFileWithLock(path, content, retry - 1)
+    }
+    await fs.promises.writeFile(path, content, { encoding: 'utf-8' }) // 执行写入操作
+  }
+  finally {
+    // eslint-disable-next-line ts/ban-ts-comment
+    // @ts-expect-error'
+    if (relase) {
+      await relase() // 释放文件锁
+    }
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,7 @@ import {
   RESOLVED_MODULE_ID_VIRTUAL,
 } from './constant'
 import { PageContext } from './context'
-import { checkPagesJsonFile } from './files'
+import { checkPagesJsonFileSync } from './files'
 import { findMacro, parseSFC } from './page'
 
 export * from './config'
@@ -28,7 +28,7 @@ export * from './page'
 export * from './types'
 export * from './utils'
 
-export async function VitePluginUniPages(userOptions: UserOptions = {}): Promise<Plugin> {
+export function VitePluginUniPages(userOptions: UserOptions = {}): Plugin {
   let ctx: PageContext
 
   // TODO: check if the pages.json file is valid
@@ -37,7 +37,7 @@ export async function VitePluginUniPages(userOptions: UserOptions = {}): Promise
     userOptions.outDir ?? 'src',
     OUTPUT_NAME,
   )
-  await checkPagesJsonFile(resolvedPagesJSONPath)
+  checkPagesJsonFileSync(resolvedPagesJSONPath)
 
   return {
     name: 'vite-plugin-uni-pages',

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -137,6 +137,10 @@ export async function execScript(options: { imports: string[], code: string, fil
   }
 }
 
+export function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 function getDefaultExport<T = any>(expr: T): T {
   return (expr as any).default === undefined ? expr : (expr as any).default
 }


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

related #245 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Platform-aware generation of pages, sub-packages, and tab bar with conditional annotations for non-default platforms.
- Bug Fixes
  - Prevents conflicting writes to pages configuration via file locking and retry.
  - Skips unnecessary rewrites when content hasn’t changed.
- Refactor
  - Plugin initializes synchronously for a more predictable startup.
  - Synchronous validation of pages configuration file.
- Chores
  - MP-Weixin debug config sets NODE_ENV=development for local testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->