### PR TITLE
fix: 排序 platforms 确保生成 pages.json 的一致性

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -595,6 +595,7 @@ function mergePlatformItems<T = any>(source: any[] | undefined, currentPlatform:
     const equalObj = existing.find(val => val.itemStr === newItemStr)
     if (equalObj) {
       equalObj.platforms.push(currentPlatform)
+      equalObj.platforms.sort()
       equalObj.platformStr = equalObj.platforms.join(' || ')
     }
     else {


### PR DESCRIPTION
## Description 描述

在构建过程中，会根据之前在 pages.json 文件中记录的注释来获取现有 platform，并在此基础上添加本次构建的新平台内容，这样可以避免在构建其他平台时覆盖掉现有平台的 pages.json 文件内容。

然而，当重新构建一个已存在的 platform 时，由于每次都会先将当前 platform 从 platforms 中移除，然后再将其添加回去，这会导致当前 platform 出现在注释的末尾。在多个 platform 交替构建的情况下，pages.json 的注释内容会不断变化。

因此，在 push platform 后进行排序，可以确保在配置不变的情况下，生成的 pages.json 文件内容保持一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved platform aggregation logic to ensure consistent ordering of platform information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->