### PR TITLE
fix: 处理exclude 配置不生效和不够健壮问题

### DIFF
--- a/packages/playground/src/pages-sub/about/components/comp.vue
+++ b/packages/playground/src/pages-sub/about/components/comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    comp
+  </div>
+</template>

--- a/packages/playground/src/pages-sub/about/components/dir/nest-comp.vue
+++ b/packages/playground/src/pages-sub/about/components/dir/nest-comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    nest-comp
+  </div>
+</template>

--- a/packages/playground/src/pages-sub/components/comp.vue
+++ b/packages/playground/src/pages-sub/components/comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    comp
+  </div>
+</template>

--- a/packages/playground/src/pages-sub/components/dir/nest-comp.vue
+++ b/packages/playground/src/pages-sub/components/dir/nest-comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    nest-comp
+  </div>
+</template>

--- a/packages/playground/src/pages-sub2/about/components/comp.vue
+++ b/packages/playground/src/pages-sub2/about/components/comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    comp
+  </div>
+</template>

--- a/packages/playground/src/pages-sub2/about/components/dir/nest-comp.vue
+++ b/packages/playground/src/pages-sub2/about/components/dir/nest-comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    nest-comp
+  </div>
+</template>

--- a/packages/playground/src/pages-sub2/about/index.vue
+++ b/packages/playground/src/pages-sub2/about/index.vue
@@ -1,0 +1,7 @@
+<script></script>
+
+<template>
+  <div>
+    my
+  </div>
+</template>

--- a/packages/playground/src/pages-sub2/about/your.vue
+++ b/packages/playground/src/pages-sub2/about/your.vue
@@ -1,0 +1,7 @@
+<script></script>
+
+<template>
+  <div>
+    your
+  </div>
+</template>

--- a/packages/playground/src/pages-sub2/components/comp.vue
+++ b/packages/playground/src/pages-sub2/components/comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    comp
+  </div>
+</template>

--- a/packages/playground/src/pages-sub2/components/dir/nest-comp.vue
+++ b/packages/playground/src/pages-sub2/components/dir/nest-comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    nest-comp
+  </div>
+</template>

--- a/packages/playground/src/pages-sub2/index.vue
+++ b/packages/playground/src/pages-sub2/index.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const title = ref('Hello')
+function nav() {
+  uni.navigateTo({
+    url: '/pages/about/index',
+  })
+}
+</script>
+
+<template>
+  <view class="content">
+    <image class="logo" src="/static/logo.png" />
+    <view class="text-area">
+      <text class="title">
+        {{ title }}
+      </text>
+    </view>
+    <button @click="nav">
+      nav
+    </button>
+  </view>
+</template>
+
+<style>
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}
+
+.logo {
+  height: 200rpx;
+  width: 200rpx;
+  margin-top: 200rpx;
+  margin-left: auto;
+  margin-right: auto;
+  margin-bottom: 50rpx;
+}
+
+.text-area {
+  display: flex;
+  justify-content: center;
+}
+
+.title {
+  font-size: 36rpx;
+  color: #8f8f94;
+}
+</style>
+
+<route lang="jsonc">
+{
+  "style": {
+    "navigationBarTitleText": "test json sub page"
+  }
+}
+</route>

--- a/packages/playground/src/pages/blog/components/comp.vue
+++ b/packages/playground/src/pages/blog/components/comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    comp
+  </div>
+</template>

--- a/packages/playground/src/pages/blog/components/dir/nest-comp.vue
+++ b/packages/playground/src/pages/blog/components/dir/nest-comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    nest-comp
+  </div>
+</template>

--- a/packages/playground/src/pages/components/comp.vue
+++ b/packages/playground/src/pages/components/comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    comp
+  </div>
+</template>

--- a/packages/playground/src/pages/components/dir/nest-comp.vue
+++ b/packages/playground/src/pages/components/dir/nest-comp.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    nest-comp
+  </div>
+</template>

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
       homePage: 'pages/index',
       debug: true,
       subPackages: ['src/pages-sub', 'src/pages-sub2'],
+      exclude: [
+        'pages*/**/components/**/*.*', // 排除所有pages 里面的 components 文件夹
+        '!pages-sub2/**/components/**/*.*', // 不排除 pages-sub2/**/components
+      ],
       // configSource: [
       //   {
       //     files: 'vite.config',

--- a/test/files.spec.ts
+++ b/test/files.spec.ts
@@ -57,3 +57,101 @@ describe('get all files', () => {
     `)
   })
 })
+
+const options2 = resolveOptions({
+  exclude: ['pages*/**/components/**/*.*'],
+}, process.cwd())
+describe('get all files except components', () => {
+  it('pages2', async () => {
+    const files = getPageFiles(pages, options2)
+    expect(files.sort()).toMatchInlineSnapshot(`
+[
+  "App.vue",
+  "components/Counter.vue",
+  "pages-sub-pages/sub-activity/pages/about/index.vue",
+  "pages-sub-pages/sub-activity/pages/home/index.vue",
+  "pages-sub-pages/sub-main/pages/about/index.nvue",
+  "pages-sub-pages/sub-main/pages/about/index.vue",
+  "pages-sub-pages/sub-main/pages/home/index.vue",
+  "pages-sub/about/index.vue",
+  "pages-sub/about/your.vue",
+  "pages-sub/index.vue",
+  "pages-sub2/about/index.vue",
+  "pages-sub2/about/your.vue",
+  "pages-sub2/index.vue",
+  "pages/A-top.vue",
+  "pages/blog/index.vue",
+  "pages/blog/post.vue",
+  "pages/define-page/async-function.vue",
+  "pages/define-page/conditional-compilation.vue",
+  "pages/define-page/function.vue",
+  "pages/define-page/nested-function.vue",
+  "pages/define-page/object.vue",
+  "pages/define-page/option-api.vue",
+  "pages/define-page/remove-console.vue",
+  "pages/define-page/yaml.vue",
+  "pages/i18n.vue",
+  "pages/index.nvue",
+  "pages/index.vue",
+  "pages/test-json.vue",
+  "pages/test-jsonc-with-comment.vue",
+  "pages/test-yaml.vue",
+  "pages/test.vue",
+]
+    `)
+  })
+})
+
+const options3 = resolveOptions({
+  exclude: [
+    // 排除所有pages 里面的 components 文件夹
+    'pages*/**/components/**/*.*',
+    // 不排除 pages-sub2/**/components
+    '!pages-sub2/**/components/**/*.*',
+  ],
+}, process.cwd())
+
+describe('get all files except components but not pages-sub2/**/components', () => {
+  it('pages3', async () => {
+    const files = getPageFiles(pages, options3)
+    expect(files.sort()).toMatchInlineSnapshot(`
+[
+  "App.vue",
+  "components/Counter.vue",
+  "pages-sub-pages/sub-activity/pages/about/index.vue",
+  "pages-sub-pages/sub-activity/pages/home/index.vue",
+  "pages-sub-pages/sub-main/pages/about/index.nvue",
+  "pages-sub-pages/sub-main/pages/about/index.vue",
+  "pages-sub-pages/sub-main/pages/home/index.vue",
+  "pages-sub/about/index.vue",
+  "pages-sub/about/your.vue",
+  "pages-sub/index.vue",
+  "pages-sub2/about/components/comp.vue",
+  "pages-sub2/about/components/dir/nest-comp.vue",
+  "pages-sub2/about/index.vue",
+  "pages-sub2/about/your.vue",
+  "pages-sub2/components/comp.vue",
+  "pages-sub2/components/dir/nest-comp.vue",
+  "pages-sub2/index.vue",
+  "pages/A-top.vue",
+  "pages/blog/index.vue",
+  "pages/blog/post.vue",
+  "pages/define-page/async-function.vue",
+  "pages/define-page/conditional-compilation.vue",
+  "pages/define-page/function.vue",
+  "pages/define-page/nested-function.vue",
+  "pages/define-page/object.vue",
+  "pages/define-page/option-api.vue",
+  "pages/define-page/remove-console.vue",
+  "pages/define-page/yaml.vue",
+  "pages/i18n.vue",
+  "pages/index.nvue",
+  "pages/index.vue",
+  "pages/test-json.vue",
+  "pages/test-jsonc-with-comment.vue",
+  "pages/test-yaml.vue",
+  "pages/test.vue",
+]
+    `)
+  })
+})

--- a/test/files.spec.ts
+++ b/test/files.spec.ts
@@ -2,33 +2,58 @@ import process from 'node:process'
 import { describe, expect, it } from 'vitest'
 import { getPageFiles, resolveOptions } from '../packages/core/src'
 
-const options = resolveOptions({}, process.cwd())
-const pages = 'packages/playground/src/pages'
+const pages = 'packages/playground/src'
 
-describe('get files', () => {
+const options = resolveOptions({}, process.cwd())
+describe('get all files', () => {
   it('pages', async () => {
     const files = getPageFiles(pages, options)
     expect(files.sort()).toMatchInlineSnapshot(`
-      [
-        "A-top.vue",
-        "blog/index.vue",
-        "blog/post.vue",
-        "define-page/async-function.vue",
-        "define-page/conditional-compilation.vue",
-        "define-page/function.vue",
-        "define-page/nested-function.vue",
-        "define-page/object.vue",
-        "define-page/option-api.vue",
-        "define-page/remove-console.vue",
-        "define-page/yaml.vue",
-        "i18n.vue",
-        "index.nvue",
-        "index.vue",
-        "test-json.vue",
-        "test-jsonc-with-comment.vue",
-        "test-yaml.vue",
-        "test.vue",
-      ]
+[
+  "App.vue",
+  "components/Counter.vue",
+  "pages-sub-pages/sub-activity/pages/about/index.vue",
+  "pages-sub-pages/sub-activity/pages/home/index.vue",
+  "pages-sub-pages/sub-main/pages/about/index.nvue",
+  "pages-sub-pages/sub-main/pages/about/index.vue",
+  "pages-sub-pages/sub-main/pages/home/index.vue",
+  "pages-sub/about/components/comp.vue",
+  "pages-sub/about/components/dir/nest-comp.vue",
+  "pages-sub/about/index.vue",
+  "pages-sub/about/your.vue",
+  "pages-sub/components/comp.vue",
+  "pages-sub/components/dir/nest-comp.vue",
+  "pages-sub/index.vue",
+  "pages-sub2/about/components/comp.vue",
+  "pages-sub2/about/components/dir/nest-comp.vue",
+  "pages-sub2/about/index.vue",
+  "pages-sub2/about/your.vue",
+  "pages-sub2/components/comp.vue",
+  "pages-sub2/components/dir/nest-comp.vue",
+  "pages-sub2/index.vue",
+  "pages/A-top.vue",
+  "pages/blog/components/comp.vue",
+  "pages/blog/components/dir/nest-comp.vue",
+  "pages/blog/index.vue",
+  "pages/blog/post.vue",
+  "pages/components/comp.vue",
+  "pages/components/dir/nest-comp.vue",
+  "pages/define-page/async-function.vue",
+  "pages/define-page/conditional-compilation.vue",
+  "pages/define-page/function.vue",
+  "pages/define-page/nested-function.vue",
+  "pages/define-page/object.vue",
+  "pages/define-page/option-api.vue",
+  "pages/define-page/remove-console.vue",
+  "pages/define-page/yaml.vue",
+  "pages/i18n.vue",
+  "pages/index.nvue",
+  "pages/index.vue",
+  "pages/test-json.vue",
+  "pages/test-jsonc-with-comment.vue",
+  "pages/test-yaml.vue",
+  "pages/test.vue",
+]
     `)
   })
 })


### PR DESCRIPTION
本次提交不仅支持普通的exclude过滤，还支持!排除项，使用示例如下：(测试用例通过）
```
exclude: [
    'pages*/**/components/**/*.*', // 排除所有pages 里面的 components 文件夹
    '!pages-sub2/**/components/**/*.*', // 不排除 pages-sub2/**/components
],
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File pattern exclusion now supports negation patterns (prefixed with !) to selectively re-include previously excluded files.

* **Tests**
  * Added comprehensive test coverage for file discovery with multiple exclusion pattern configurations.

* **Chores**
  * Added playground component fixtures across multiple directory structures for testing purposes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->