### PR TITLE
fix(types): 修复未启用 dts 时 virtual:uni-pages 类型错误

### DIFF
--- a/packages/core/client.d.ts
+++ b/packages/core/client.d.ts
@@ -1,3 +1,5 @@
+/// <reference path="./global.d.ts" />
+
 declare module 'virtual:uni-pages' {
   import type { SubPackage } from './src/config/types/index'
   import type { PageMetaDatum } from './src/types'
@@ -5,9 +7,3 @@ declare module 'virtual:uni-pages' {
   export const pages: PageMetaDatum[]
   export const subPackages: SubPackage[]
 }
-
-declare global {
-  const definePage: import('.').DefinePage
-}
-
-export {}

--- a/packages/core/global.d.ts
+++ b/packages/core/global.d.ts
@@ -1,0 +1,5 @@
+declare global {
+  const definePage: import('.').DefinePage
+}
+
+export {}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -45,6 +45,7 @@
   "files": [
     "client.d.ts",
     "dist",
+    "global.d.ts",
     "index.d.ts"
   ],
   "scripts": {


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述

对于 `declare module 'virtual:uni-pages'` 添加顶层 export 会导致 import 时类型错误，而 `declare global` 需要顶层 export 才能正常工作，所以这个 PR 拆分出独立的 `global.d.ts` 以解决这个问题。

由于启用 `dts` 选项后会在 `uni-pages.d.ts` 中生成 `declare module 'virtual:uni-pages'`，所以掩盖了此问题。

Thx @edwinhuish and [@uni-ku/pages-json](https://github.com/uni-ku/pages-json).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized global type declarations for improved module structure and type accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->