### PR TITLE
fix: use atomic write to prevent race condition when writing pages.json

### DIFF
--- a/packages/core/src/files.ts
+++ b/packages/core/src/files.ts
@@ -120,7 +120,10 @@ export async function writeFileWithLock(path: string, content: string, retry = 3
       await sleep(500)
       return writeFileWithLock(path, content, retry - 1)
     }
-    await fs.promises.writeFile(path, content, { encoding: 'utf-8' }) // 执行写入操作
+    // Use atomic write: write to temp file first, then rename
+    const tempPath = `${path}.${Date.now()}.tmp`
+    await fs.promises.writeFile(tempPath, content, { encoding: 'utf-8' })
+    await fs.promises.rename(tempPath, path)
   }
   finally {
     // eslint-disable-next-line ts/ban-ts-comment


### PR DESCRIPTION
<!--

DO NOT INGORE THE TEMPLATE!
请不要忽视这个模板！

Before submitting the PR, please make sure you do the following:
在提交 PR 之前，请确保你做到以下几点：

- Read the [Contributing Guide](https://github.com/antfu/contribute) and [Notes from a tired maintainer](https://github.com/pi0/tired-maintainer).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.
- 阅读 [贡献指南](https://github.com/antfu/contribute) 和 [一位疲惫的维护者的笔记](https://github.com/ModyQyW/tired-maintainer)。
- 检查是否已经有一个以同样方式解决该问题的 PR，以避免重复创建。
- 在这个 PR 中描述 **PR 所要解决的问题**，或者引用它所解决的问题（例如 `fixes #123`）。
- 理想情况下，提交没有这个 PR 的情况下失败但在有 PR 的情况下通过的相关测试。

-->

### Description 描述
在执行 uni dev -p app 开发模式时，pages.json 会被意外清空，导致 @uni-helper/vite-plugin-uni-layouts 等其他插件读取时崩溃：
```
TypeError: Cannot read properties of undefined (reading 'pages')
    at loadPagesJson (vite-plugin-uni-layouts/dist/index.mjs:68:11)
```
## 根本原因 (Root Cause)

`writeFileWithLock` 函数使用 `fs.promises.writeFile` 写入 `pages.json`，该 API 的行为是**先截断（清空）文件，再写入内容**：

```javascript
// 当前代码
await fs.promises.writeFile(path, content, { encoding: "utf-8" });
```

这会产生一个**竞态条件（Race Condition）**：

| 时序 | vite-plugin-uni-pages | vite-plugin-uni-layouts |
|-----|----------------------|------------------------|
| T1 | `writeFile` 开始 → **文件被截断为空** | - |
| T2 | - | chokidar 检测到文件变化 |
| T3 | - | **读取文件 → 内容为空** → 💥 崩溃 |
| T4 | 写入完整内容 | - |

虽然使用了 `proper-lockfile` 进行文件锁定，但文件锁只能防止并发写入，无法阻止其他进程在写入过程中读取。

<!--

Please insert your description here and provide especially info about the "what" this PR is solving
请在此插入你的描述，并提供有关该 PR 所解决的 **问题** 的信息。


## 解决方案 (Solution)

使用**原子写入（Atomic Write）**模式：先写入临时文件，再通过 `rename` 原子性替换目标文件。

```javascript
// 修复后
const tempPath = `${path}.${Date.now()}.tmp`;
await fs.promises.writeFile(tempPath, content, { encoding: "utf-8" });
await fs.promises.rename(tempPath, path);
```

`rename` 是 POSIX 原子操作，目标文件要么是旧内容，要么是新内容，永远不会处于空状态。
-->

### Linked Issues 关联的 Issues

### Additional context 额外上下文

<!--

e.g. is there anything you'd like reviewers to focus on?
例如，有什么东西是你希望审查人关注的？

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file write reliability and atomic operation handling to ensure data integrity during concurrent write scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->