### PR TITLE
fix(core): 修复 homePage 配置无效及首页排序问题

### DIFF
--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -230,7 +230,22 @@ export class PageContext {
     const hasHome = result.some(({ type }) => type === 'home')
     if (!hasHome) {
       const isFoundHome = result.some((item) => {
-        const isFound = this.options.homePage.find(v => (v === item.path))
+        const isFound = this.options.homePage.find(v => {
+          if (v === item.path)
+            return true
+
+          const normalizedItemPath = item.path.replace(/\\/g, '/')
+          const normalizedConfigPath = v.replace(/\\/g, '/')
+
+          if (normalizedItemPath.endsWith(normalizedConfigPath) || normalizedItemPath.endsWith(`/${normalizedConfigPath}`))
+            return true
+
+          const pathWithoutExt = normalizedItemPath.replace(/\.[^.]+$/, '')
+          if (pathWithoutExt === normalizedConfigPath || pathWithoutExt.endsWith(`/${normalizedConfigPath}`))
+            return true
+
+          return false
+        })
         if (isFound)
           item.type = 'home'
 
@@ -432,6 +447,16 @@ export class PageContext {
 
     // pages
     pageJson.pages = mergePlatformItems(oldPages as any, currentPlatform, this.pageMetaData, 'path')
+
+    // 确保首页排在第一位
+    if (pageJson.pages && pageJson.pages.length > 0) {
+      const pagesArray = pageJson.pages as unknown as PageMetaDatum[]
+      const homeIndex = pagesArray.findIndex((page: any) => page.type === 'home')
+      if (homeIndex > 0) {
+        const homePage = pagesArray.splice(homeIndex, 1)[0]
+        pagesArray.unshift(homePage)
+      }
+    }
 
     // subPackages
     pageJson.subPackages = oldSubPackages || new CommentArray<CommentObject>()

--- a/packages/schema/schema.json
+++ b/packages/schema/schema.json
@@ -2834,13 +2834,13 @@
         "plugins": {
           "additionalProperties": {
             "properties": {
+              "export": {
+                "type": "string"
+              },
               "provider": {
                 "type": "string"
               },
               "version": {
-                "type": "string"
-              },
-              "export": {
                 "type": "string"
               }
             },
@@ -3005,9 +3005,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "list"
-      ],
       "type": "object"
     },
     "TabBarIconFont": {

--- a/test/generate.spec.ts
+++ b/test/generate.spec.ts
@@ -33,6 +33,14 @@ describe('generate routes', () => {
     expect(routes).toMatchInlineSnapshot(`
       "[
         {
+          "path": "../packages/playground/src/pages/index",
+          "type": "home",
+          "middlewares": [
+            "auth",
+            "test"
+          ]
+        },
+        {
           "path": "../packages/playground/src/pages/A-top",
           "type": "page"
         },
@@ -42,14 +50,6 @@ describe('generate routes', () => {
           "style": {
             "navigationBarTitleText": "%app.name%"
           }
-        },
-        {
-          "path": "../packages/playground/src/pages/index",
-          "type": "page",
-          "middlewares": [
-            "auth",
-            "test"
-          ]
         },
         {
           "path": "../packages/playground/src/pages/test-json",


### PR DESCRIPTION
## 问题
设置了 `homePage` 配置后，生成的 pages.json 中首页不是排在第一位。

## 原因
1. `setHomePage` 方法中使用精确字符串匹配，导致路径格式不一致时无法匹配
2. `genratePagesJSON` 方法中 `mergePlatformItems` 函数使用 Map 存储页面，导致排序丢失

## 修复
1. 改进 `setHomePage` 方法，支持模糊路径匹配：
   - 精确匹配
   - 路径后缀匹配
   - 去除扩展名后匹配
   - Windows 路径分隔符处理

2. 在 `genratePagesJSON` 中添加二次排序，确保首页排在 pages 数组第一位

## 测试
- 所有 8 个测试用例通过
- 首页被正确识别并排在第一位

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved home page detection with more flexible path matching, including support for trailing extensions and path normalization
  * Home pages are now consistently positioned first in page listings

* **Schema Updates**
  * Updated validation to make TabBar list property optional
  * Reorganized schema property definitions for enhanced clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->